### PR TITLE
Set cosign as default db

### DIFF
--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: cosign
       PGDATA: /data/postgres
     volumes:
       - postgres:/data/postgres


### PR DESCRIPTION
This way the database gets automatically created when postgres initializes, resolving the below issue when starting the backend:

```
docker-compose up
...
backend     | django.db.utils.OperationalError: connection to server at "cosign-postgres" (172.23.0.3), port 5432 failed: FATAL:  database "cosign" does not exist
```